### PR TITLE
Librina: CDAP Encoder modifications for swig

### DIFF
--- a/librina/include/librina/cdap_v2.h
+++ b/librina/include/librina/cdap_v2.h
@@ -25,6 +25,7 @@
 #define CDAP_PROVIDER_H_
 #include <string>
 
+#include <librina/common.h>
 #include <librina/concurrency.h>
 #include "cdap_rib_structures.h"
 
@@ -606,25 +607,6 @@ extern void fini(void);
 
 //TODO remove
 extern void destroy(int port);
-
-template<class T>
-class Encoder{
-public:
-	virtual ~Encoder(){}
-	/// Converts an object to a byte array, if this object is recognized by the encoder
-	/// @param object
-	/// @throws exception if the object is not recognized by the encoder
-	/// @return
-	virtual void encode(const T &obj, ser_obj_t& serobj) = 0;
-	/// Converts a byte array to an object of the type specified by "className"
-	/// @param byte[] serializedObject
-	/// @param objectClass The type of object to be decoded
-	/// @throws exception if the byte array is not an encoded in a way that the
-	/// encoder can recognize, or the byte array value doesn't correspond to an
-	/// object of the type "className"
-	/// @return
-	virtual void decode(const ser_obj_t &serobj,T &des_obj) = 0;
-};
 
 /// String encoder
 class StringEncoder : public Encoder<std::string>{

--- a/librina/include/librina/common.h
+++ b/librina/include/librina/common.h
@@ -740,6 +740,26 @@ public:
 	}
 };
 
+/// Template interface for encoding and decoding of objects (object <--> buffer)
+template<class T>
+class Encoder{
+public:
+	virtual ~Encoder(){}
+	/// Converts an object to a byte array, if this object is recognized by the encoder
+	/// @param object
+	/// @throws exception if the object is not recognized by the encoder
+	/// @return
+	virtual void encode(const T &obj, ser_obj_t& serobj) = 0;
+	/// Converts a byte array to an object of the type specified by "className"
+	/// @param byte[] serializedObject
+	/// @param objectClass The type of object to be decoded
+	/// @throws exception if the byte array is not an encoded in a way that the
+	/// encoder can recognize, or the byte array value doesn't correspond to an
+	/// object of the type "className"
+	/// @return
+	virtual void decode(const ser_obj_t &serobj,T &des_obj) = 0;
+};
+
 /**
  * Initialize librina providing the local Netlink port-id where this librina
  * instantiation will be bound

--- a/librina/wrap/librina.i
+++ b/librina/wrap/librina.i
@@ -450,10 +450,16 @@ DOWNCAST_IPC_EVENT_CONSUMER(eventTimedWait);
 %include "librina/patterns.h"
 %include "librina/concurrency.h"
 %include "librina/common.h"
+
+%template(TempStringEncoder) rina::Encoder<std::string>;
+%template(TempIntEncoder) rina::Encoder<int>;
+
+
 %include "librina/application.h"
 %include "librina/cdap_rib_structures.h"
 %include "librina/cdap_v2.h"
 %include "librina/ipc-api.h"
+
 
 /* Macro for defining collection iterators */
 %define MAKE_COLLECTION_ITERABLE( ITERATORNAME, JTYPE, CPPCOLLECTION, CPPTYPE )
@@ -517,4 +523,3 @@ MAKE_COLLECTION_ITERABLE(UnsignedIntListIterator, Long, std::list, unsigned int)
 %template(StringList) std::list<std::string>;
 %template(FlowInformationList) std::list<rina::FlowInformation>;
 %template(UnsignedIntList) std::list<unsigned int>;
-

--- a/rinad/src/common/encoder.cc
+++ b/rinad/src/common/encoder.cc
@@ -245,7 +245,7 @@ void DataTransferConstantsEncoder::decode(
 
 
 // CLASS DirectoryForwardingTableEntryEncoder
-void DirectoryForwardingTableEntryEncoder::encode(
+void DFTEEncoder::encode(
 	const rina::DirectoryForwardingTableEntry &obj, 
 	rina::cdap_rib::ser_obj_t& serobj)
 {
@@ -261,7 +261,7 @@ void DirectoryForwardingTableEntryEncoder::encode(
 	gpb.SerializeToArray(serobj.message_, serobj.size_);
 }
 
-void DirectoryForwardingTableEntryEncoder::decode(
+void DFTEEncoder::decode(
 	const rina::cdap_rib::ser_obj_t &serobj, 
 	rina::DirectoryForwardingTableEntry &des_obj)
 {
@@ -277,6 +277,20 @@ void DirectoryForwardingTableEntryEncoder::decode(
 
 }
 
+// CLASS DFTEListEncoder
+void DFTEListEncoder::encode(
+	const std::list<rina::DirectoryForwardingTableEntry> &obj,
+	rina::cdap_rib::ser_obj_t& serobj)
+{
+
+
+}
+void DFTEListEncoder::decode(const rina::cdap_rib::ser_obj_t &serobj, 
+	std::list<rina::DirectoryForwardingTableEntry> &des_obj)
+{
+
+
+}
 
 // CLASS QoSCubeEncoder
 namespace cube_enc_helpers
@@ -602,6 +616,20 @@ void QoSCubeEncoder::decode(const rina::cdap_rib::ser_obj_t &serobj,
 	des_obj.undetected_bit_error_rate_ = gpb.undetectedbiterrorrate();
 }
 
+/// CLASS QoSCubeListEncoder
+void QoSCubeListEncoder::encode(const <std::list<rina::QoSCube> &obj, 
+	rina::cdap_rib::ser_obj_t& serobj)
+{
+
+
+}
+void QoSCubeListEncoder::decode(const rina::cdap_rib::ser_obj_t &serobj, 
+	<std::list<rina::QoSCube> &des_obj)
+{
+
+
+}
+
 //Class WhatevercastNameEncoder
 void WhatevercastNameEncoder::encode(const rina::WhatevercastName &obj,
 	rina::cdap_rib::ser_obj_t& serobj)
@@ -633,6 +661,21 @@ void WhatevercastNameEncoder::decode(const rina::cdap_rib::ser_obj_t &serobj,
 	for(int i=0; i<gpb.setmembers_size(); i++) {
 		des_obj.set_members_.push_back(gpb.setmembers(i));
 	}
+}
+
+/// Class WhatevercastNameListEncoder
+void WhatevercastNameListEncoder::encode(
+	const std::list<rina::Encoder<rina::WhatevercastName> &obj,
+	rina::cdap_rib::ser_obj_t& serobj)
+{
+
+
+}
+void WhatevercastNameListEncoder::decode(const rina::cdap_rib::ser_obj_t &serobj, 
+	std::list<rina::Encoder<rina::WhatevercastName> &des_obj)
+{
+
+
 }
 
 //Class NeighborEncoder
@@ -671,6 +714,22 @@ void NeighborEncoder::decode(const rina::cdap_rib::ser_obj_t &serobj,
 			""));
 	}
 }
+
+
+/// CLASS NeighborListEncoder
+void NeighborListEncoder::encode(
+	const std::list<rina::Encoder<rina::Neighbor> > &obj,
+	rina::cdap_rib::ser_obj_t& serobj)
+{
+
+}
+void NeighborListEncoder::decode(const rina::cdap_rib::ser_obj_t &serobj, 
+	std::list<rina::Encoder<rina::Neighbor> > &des_obj
+{
+
+
+}
+
 
 // Class IntEncoder
 void IntEncoder::encode(const int &obj, rina::cdap_rib::ser_obj_t& serobj)

--- a/rinad/src/common/encoder.h
+++ b/rinad/src/common/encoder.h
@@ -21,8 +21,11 @@
 
 #ifndef ENCODER_H_
 #define ENCODER_H_
-
 #ifdef __cplusplus
+
+#include <librina/cdap_v2.h>
+
+#include <list>
 
 namespace rinad {
 
@@ -115,28 +118,10 @@ public:
 	static const std::string WHATEVERCAST_NAME_RIB_OBJECT_CLASS;
 };
 
-template<class T>
-class Encoder{
-public:
-	virtual ~Encoder(){}
-	/// Converts an object to a byte array, if this object is recognized by the 
-	///encoder
-	/// @param object
-	/// @throws exception if the object is not recognized by the encoder
-	/// @return
-	virtual void encode(const T &obj, rina::cdap_rib::ser_obj_t& serobj) = 0;
-	/// Converts a byte array to an object of the type specified by "className"
-	/// @param byte[] serializedObject
-	/// @param objectClass The type of object to be decoded
-	/// @throws exception if the byte array is not an encoded in a way that the
-	/// encoder can recognize, or the byte array value doesn't correspond to an
-	/// object of the type "className"
-	/// @return
-	virtual void decode(const rina::cdap_rib::ser_obj_t &serobj,T &des_obj) = 0;
-};
-
 /// Encoder of the DataTransferConstants object
-class DataTransferConstantsEncoder: public Encoder<rina::DataTransferConstants> {
+class DataTransferConstantsEncoder: 
+	public rina::Encoder<rina::DataTransferConstants> 
+{
 public:
 	void encode(const rina::DataTransferConstants &obj, 
 		rina::cdap_rib::ser_obj_t& serobj);
@@ -145,8 +130,9 @@ public:
 };
 
 /// Encoder of DirectoryForwardingTableEntry object
-class DirectoryForwardingTableEntryEncoder: 
-	public Encoder<rina::DirectoryForwardingTableEntry> {
+class DFTEEncoder: 
+	public rina::Encoder<rina::DirectoryForwardingTableEntry> 
+{
 public:
 	void encode(const rina::DirectoryForwardingTableEntry &obj, 
 		rina::cdap_rib::ser_obj_t& serobj);
@@ -154,17 +140,39 @@ public:
 		rina::DirectoryForwardingTableEntry &des_obj);
 };
 
+/// Encoder of DirectoryForwardingTableEntryList object
+class DFTEListEncoder: 
+	public rina::Encoder< std::list<rina::DirectoryForwardingTableEntry> >
+{
+public:
+	void encode(const std::list<rina::DirectoryForwardingTableEntry> &obj,
+		rina::cdap_rib::ser_obj_t& serobj);
+	void decode(const rina::cdap_rib::ser_obj_t &serobj, 
+		std::list<rina::DirectoryForwardingTableEntry> &des_obj);
+};
+
 /// Encoder of QoSCube object
-class QoSCubeEncoder: public Encoder<rina::QoSCube> {
+class QoSCubeEncoder: public rina::Encoder<rina::QoSCube> 
+{
 public:
 	void encode(const rina::QoSCube &obj, rina::cdap_rib::ser_obj_t& serobj);
 	void decode(const rina::cdap_rib::ser_obj_t &serobj, 
 		rina::QoSCube &des_obj);
 };
 
+/// Encoder of QoSCube list object
+class QoSCubeListEncoder: public rina::Encoder<std::list<rina::QoSCube> >
+{
+public:
+	void encode(const <std::list<rina::QoSCube> &obj, 
+		rina::cdap_rib::ser_obj_t& serobj);
+	void decode(const rina::cdap_rib::ser_obj_t &serobj, 
+		<std::list<rina::QoSCube> &des_obj);
+};
 
 /// Encoder of WhatevercastName object
-class WhatevercastNameEncoder: public Encoder<rina::WhatevercastName> {
+class WhatevercastNameEncoder: public rina::Encoder<rina::WhatevercastName> 
+{
 public:
 	void encode(const rina::WhatevercastName &obj, 
 		rina::cdap_rib::ser_obj_t& serobj);
@@ -172,23 +180,48 @@ public:
 		rina::WhatevercastName &des_obj);
 };
 
+/// Encoder of WhatevercastName list object
+class WhatevercastNameListEncoder: 
+	public std::list<rina::Encoder<rina::WhatevercastName> >
+{
+public:
+	void encode(const std::list<rina::Encoder<rina::WhatevercastName> &obj,
+		rina::cdap_rib::ser_obj_t& serobj);
+	void decode(const rina::cdap_rib::ser_obj_t &serobj, 
+		std::list<rina::Encoder<rina::WhatevercastName> &des_obj);
+};
+
+
 /// Encoder of Neighbor object
-class NeighborEncoder: public Encoder<rina::Neighbor> {
+class NeighborEncoder: public rina::Encoder<rina::Neighbor> 
+{
 public:
 	void encode(const rina::Neighbor &obj, rina::cdap_rib::ser_obj_t& serobj);
 	void decode(const rina::cdap_rib::ser_obj_t &serobj, 
 		rina::Neighbor &des_obj);
 };
 
+/// Encoder of Neighbor list object
+class NeighborListEncoder: public std::list<rina::Encoder<rina::Neighbor> > 
+{
+public:
+	void encode(const std::list<rina::Encoder<rina::Neighbor> > &obj,
+		rina::cdap_rib::ser_obj_t& serobj);
+	void decode(const rina::cdap_rib::ser_obj_t &serobj, 
+		std::list<rina::Encoder<rina::Neighbor> > &des_obj);
+};
+
 /// Encoder of Watchdog
-class IntEncoder: public Encoder<int>{
+class IntEncoder: public rina::Encoder<int>
+{
 public:
 	void encode(const int &obj, rina::cdap_rib::ser_obj_t& serobj);
 	void decode(const rina::cdap_rib::ser_obj_t &serobj, int &des_obj);
 };
 
 /// Encoder of the AData object
-class ADataObjectEncoder: public Encoder<rina::ADataObject> {
+class ADataObjectEncoder: public rina::Encoder<rina::ADataObject> 
+{
 public:
 	void encode(const rina::ADataObject &obj, 
 		rina::cdap_rib::ser_obj_t& serobj);

--- a/rinad/src/ipcp/ipc-process.cc
+++ b/rinad/src/ipcp/ipc-process.cc
@@ -202,7 +202,7 @@ void IPCProcessImpl::init_encoder() {
 	encoder_->addEncoder(EncoderConstants::DATA_TRANSFER_CONSTANTS_RIB_OBJECT_CLASS,
 			new DataTransferConstantsEncoder());
 	encoder_->addEncoder(EncoderConstants::DFT_ENTRY_RIB_OBJECT_CLASS,
-			new DirectoryForwardingTableEntryEncoder());
+			new DFTEEncoder());
 	encoder_->addEncoder(EncoderConstants::DFT_ENTRY_SET_RIB_OBJECT_CLASS,
 			new DirectoryForwardingTableEntryListEncoder());
 	encoder_->addEncoder(EncoderConstants::ENROLLMENT_INFO_OBJECT_CLASS,

--- a/rinad/src/ipcp/rib-daemon.cc
+++ b/rinad/src/ipcp/rib-daemon.cc
@@ -29,32 +29,6 @@
 
 namespace rinad {
 
-//TODO remove
-template<class T>
-class Encoder{
-public:
- virtual ~Encoder(){}
- /// Converts an object to a byte array, if this object is recognized by the encoder
- /// @param object
- /// @throws exception if the object is not recognized by the encoder
- /// @return
- virtual static void encode(const T &obj, rina::cdap_rib::ser_obj_t& serobj) = 0;
- /// Converts a byte array to an object of the type specified by "className"
- /// @param byte[] serializedObject
- /// @param objectClass The type of object to be decoded
- /// @throws exception if the byte array is not an encoded in a way that the
- /// encoder can recognize, or the byte array value doesn't correspond to an
- /// object of the type "className"
- /// @return
- virtual static void decode(const rina::cdap_rib::ser_obj_t &serobj,T &des_obj) = 0;
-};/// Encoder of the AData object
-
-class ADataObjectEncoder: public Encoder<rina::ADataObject> {
-public:
- void static encode(const rina::ADataObject &obj, rina::cdap_rib::ser_obj_t& serobj);
- void static decode(const rina::cdap_rib::ser_obj_t &serobj, rina::ADataObject &des_obj);
-};
-
 //Class ManagementSDUReader data
 ManagementSDUReaderData::ManagementSDUReaderData(unsigned int max_sdu_size)
 {

--- a/rinad/src/ipcp/test-encoders.cc
+++ b/rinad/src/ipcp/test-encoders.cc
@@ -625,7 +625,7 @@ int main()
 	encoder.addEncoder(rinad::EncoderConstants::DATA_TRANSFER_CONSTANTS_RIB_OBJECT_CLASS,
 			new rinad::DataTransferConstantsEncoder());
 	encoder.addEncoder(rinad::EncoderConstants::DFT_ENTRY_RIB_OBJECT_CLASS,
-			new rinad::DirectoryForwardingTableEntryEncoder());
+			new rinad::DFTEEncoder());
 	encoder.addEncoder(rinad::EncoderConstants::DFT_ENTRY_SET_RIB_OBJECT_CLASS,
 			new rinad::DirectoryForwardingTableEntryListEncoder());
 	encoder.addEncoder(rinad::EncoderConstants::DFT_ENTRY_SET_RIB_OBJECT_CLASS,


### PR DESCRIPTION
CDAP encoder has been moved to common.h while instantiations have been
allocated in cdap_v2.h. SWIG interface file has been adapted to allow
template instantiation in Java
